### PR TITLE
add true position for energy depositions

### DIFF
--- a/numl/NeutrinoML/HDF5Maker_module.cc
+++ b/numl/NeutrinoML/HDF5Maker_module.cc
@@ -361,7 +361,7 @@ void HDF5Maker::beginSubRun(art::SubRun const& sr) {
       hep_hpc::hdf5::make_ntuple({fFile, "event_table", 1000},
         hep_hpc::hdf5::make_column<int>("event_id", 3),
         hep_hpc::hdf5::make_scalar_column<int>("is_cc"),
-	hep_hpc::hdf5::make_scalar_column<int>("nu_pdg"),    
+        hep_hpc::hdf5::make_scalar_column<int>("nu_pdg"),    
         hep_hpc::hdf5::make_scalar_column<float>("nu_energy"),
         hep_hpc::hdf5::make_scalar_column<float>("lep_energy"),
         hep_hpc::hdf5::make_column<float>("nu_dir", 3)

--- a/numl/NeutrinoML/HDF5Maker_module.cc
+++ b/numl/NeutrinoML/HDF5Maker_module.cc
@@ -3,7 +3,7 @@
 // Plugin Type: analyzer (art v3_06_03)
 // File:        HDF5Maker_module.cc
 //
-// Generated at Wed May  5 08:23:31 2021 by Jeremy Hewes using cetskelgen
+// Generated at Wed May  5 08:23:31 2021 by V Hewes using cetskelgen
 // from cetlib version v3_11_01.
 ////////////////////////////////////////////////////////////////////////
 

--- a/numl/NeutrinoML/HDF5Maker_module.cc
+++ b/numl/NeutrinoML/HDF5Maker_module.cc
@@ -62,7 +62,7 @@ private:
 
   hep_hpc::hdf5::Ntuple<hep_hpc::hdf5::Column<int, 1>,    // event id (run, subrun, event)
                         hep_hpc::hdf5::Column<int, 1>,    // is cc
-      hep_hpc::hdf5::Column<int, 1>, // nu pdg
+                        hep_hpc::hdf5::Column<int, 1>, // nu pdg
                         hep_hpc::hdf5::Column<float, 1>,  // nu energy
                         hep_hpc::hdf5::Column<float, 1>,  // lep energy
                         hep_hpc::hdf5::Column<float, 1>   // nu dir (x, y, z)


### PR DESCRIPTION
this adds a true XYZ coordinate for every energy deposition in the table. this only works for DUNE; the MicroBooNE particle map workflow currently just fills those columns with `nan` values.